### PR TITLE
[Bugfix]: Fix page error if empty title, meta-tag or academicDegree

### DIFF
--- a/Classes/Controller/StudyCourseController.php
+++ b/Classes/Controller/StudyCourseController.php
@@ -333,7 +333,7 @@ class StudyCourseController extends AbstractController
         } else if (!empty($studyCourse->getAcademicDegree())) {
             FrontendUtility::getTyposcriptFrontendController()->page['title'] =
                 $studyCourse->getTitle() . ' - ' . $studyCourse->getAcademicDegree()->getDegree();
-        }else {
+        } else {
             FrontendUtility::getTyposcriptFrontendController()->page['title'] = $studyCourse->getTitle();
         }
         if (!empty($studyCourse->getMetaDescription())) {

--- a/Classes/Controller/StudyCourseController.php
+++ b/Classes/Controller/StudyCourseController.php
@@ -330,9 +330,11 @@ class StudyCourseController extends AbstractController
     {
         if (!empty($studyCourse->getMetaPagetitle())) {
             FrontendUtility::getTyposcriptFrontendController()->page['title'] = $studyCourse->getMetaPagetitle();
-        } else {
+        } else if (!empty($studyCourse->getAcademicDegree())) {
             FrontendUtility::getTyposcriptFrontendController()->page['title'] =
                 $studyCourse->getTitle() . ' - ' . $studyCourse->getAcademicDegree()->getDegree();
+        }else {
+            FrontendUtility::getTyposcriptFrontendController()->page['title'] = $studyCourse->getTitle();
         }
         if (!empty($studyCourse->getMetaDescription())) {
             $metaDescription = '<meta name="description" content="' . $studyCourse->getMetaDescription() . '">';


### PR DESCRIPTION
Fixes Page Error if studyfinder record has no AcademicDegree (or selectbox is default value 0) and meta title is not set

Version 7.1.0.
TYPO3 9.5.26