### PR TITLE
[BUGFIX] add missing quotes and extend the condition to check if data sys_language_uid not NULL

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -1,4 +1,4 @@
-<div class="in2studyfinder no-js" {f:if(condition: isAjaxRequest, then: 'data-in2studyfinder-isAjax="1"')} {f:if(condition: data.pid, then: 'data-pid="{data.pid}"')} {f:if(condition: data.uid, then: 'data-plugin-uid="{data.uid}"')} {f:if(condition: '{data.sys_language_uid} >= 0', then: 'data-in2studyfinder-language={data.sys_language_uid}')}>
+<div class="in2studyfinder no-js" {f:if(condition: isAjaxRequest, then: 'data-in2studyfinder-isAjax="1"')} {f:if(condition: data.pid, then: 'data-pid="{data.pid}"')} {f:if(condition: data.uid, then: 'data-plugin-uid="{data.uid}"')} {f:if(condition: '{data.sys_language_uid} && {data.sys_language_uid} >= 0', then: 'data-in2studyfinder-language="{data.sys_language_uid}"')}>
 	<f:render section="main"/>
 
 	<f:render partial="Loader" arguments="{_all}"/>


### PR DESCRIPTION
If `config.sys_language_uid` not set, `sys_language_uid` return `NULL` and the condition is true.
So I expanded the condition to first see if the value is set at all, and then I added the missing quotes.

[Here](view-source:https://www.hs-kempten.de/) in the source code you can see the error well:

![image](https://user-images.githubusercontent.com/1122085/171009206-1952cf99-8a7e-4a9e-b5a4-b8a4e35eb2c8.png)
