### PR TITLE
[BUGFIX] Pass configured StoragePids to query settings

### DIFF
--- a/Classes/Service/FilterService.php
+++ b/Classes/Service/FilterService.php
@@ -209,7 +209,7 @@ class FilterService
 
         if (class_exists($repositoryClassName)) {
             $defaultQuerySettings = GeneralUtility::makeInstance(QuerySettingsInterface::class);
-            $defaultQuerySettings->setStoragePageIds([$this->settings['settingsPid']]);
+            $defaultQuerySettings->setStoragePageIds($this->extensionSettings->getConfiguredStoragePids());
             $languageAspect = $defaultQuerySettings->getLanguageAspect();
             $languageAspect = new LanguageAspect($languageAspect->getId(), $languageAspect->getContentId(), LanguageAspect::OVERLAYS_MIXED);
             $defaultQuerySettings->setLanguageAspect($languageAspect);


### PR DESCRIPTION
The extension allows for a list of PIDs as well as a recursion level. By using the helper method from ExtensionSettings, both of these are now taken into account when applying filters.

Fixes: #45